### PR TITLE
Lifetime fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ path = "src/lib.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-"generic-array" = "^0.13.2"
-"typenum" = "^1.11.2"
+"generic-array" = "^0.14"
+"typenum" = "^1.11"
 
 [dev-dependencies]
-"quickcheck" = "^0.9.2"
+"quickcheck" = "^0.9"
 "quickcheck_macros" = "^0.9"

--- a/src/compute/ops.rs
+++ b/src/compute/ops.rs
@@ -13,34 +13,34 @@ use std::{
 };
 use typenum::{bit::B1, consts::*, Add1, Sub1, Sum, Unsigned};
 
-pub struct Cn<'g, F, N, M>
+pub struct Cn<F, N, M>
 where
     F: Recursive<M>,
     N: Unsigned,
-    M: ArrayLength<&'g dyn Computable<N>>,
+    M: ArrayLength<Box<dyn Computable<N>>>,
 {
     f: F,
-    gs: GenericArray<&'g dyn Computable<N>, M>,
+    gs: GenericArray<Box<dyn Computable<N>>, M>,
 }
 
-impl<'g, F, N, M> std::fmt::Debug for Cn<'g, F, N, M>
+impl<F, N, M> std::fmt::Debug for Cn<F, N, M>
 where
     F: Recursive<M>,
     N: Unsigned,
-    M: ArrayLength<&'g dyn Computable<N>>,
+    M: ArrayLength<Box<dyn Computable<N>>>,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Cn[{:?}, {:?}]", self.f, self.gs)
     }
 }
 
-impl<'g, F, N, M> Cn<'g, F, N, M>
+impl<F, N, M> Cn<F, N, M>
 where
     F: Recursive<M>,
     N: Unsigned,
-    M: ArrayLength<&'g dyn Computable<N>>,
+    M: ArrayLength<Box<dyn Computable<N>>>,
 {
-    pub fn new(f: F, gs: GenericArray<&'g dyn Computable<N>, M>) -> Self {
+    pub fn new(f: F, gs: GenericArray<Box<dyn Computable<N>>, M>) -> Self {
         Cn { f, gs }
     }
 }
@@ -48,7 +48,7 @@ where
 #[macro_export]
 macro_rules! cn {
     ($f:expr; $N:ty; $($g:expr),*) => {
-        Cn::new($f, funcs![$N; $(&$g),*])
+        Cn::new($f, funcs![$N; $($g),*])
     }
 }
 
@@ -62,19 +62,19 @@ macro_rules! cn {
 // {
 // }
 
-impl<'g, F, N, M> Recursive<N> for Cn<'g, F, N, M>
+impl<F, N, M> Recursive<N> for Cn<F, N, M>
 where
     F: Recursive<M>,
     N: Unsigned,
-    M: ArrayLength<&'g dyn Computable<N>>,
+    M: ArrayLength<Box<dyn Computable<N>>>,
 {
 }
 
-impl<'g, F, N, M> Compute<N> for Cn<'g, F, N, M>
+impl<F, N, M> Compute<N> for Cn<F, N, M>
 where
     F: Recursive<M> + Compute<M>,
     N: ArrayLength<usize>,
-    M: ArrayLength<usize> + ArrayLength<&'g dyn Computable<N>>,
+    M: ArrayLength<usize> + ArrayLength<Box<dyn Computable<N>>>,
 {
     fn call(&self, x: &GenericArray<usize, N>) -> Option<usize> {
         self.gs

--- a/src/funcs/basic.rs
+++ b/src/funcs/basic.rs
@@ -3,12 +3,12 @@ use std::{marker::PhantomData, ops::Sub};
 use typenum::{consts::U1, Diff, NonZero, Unsigned};
 
 #[derive(Debug)]
-pub struct Zero {}
-pub const Z: Zero = Zero {};
+pub struct Zero;
+pub const Z: Zero = Zero;
 
 #[derive(Debug)]
-pub struct Succ {}
-pub const S: Succ = Succ {};
+pub struct Succ;
+pub const S: Succ = Succ;
 
 pub struct Id<N, K>
 where

--- a/src/funcs/common.rs
+++ b/src/funcs/common.rs
@@ -52,8 +52,8 @@ pub fn difference() -> impl Computable<U2> {
 // }
 // Stopgap solution:
 #[derive(Debug)]
-pub struct Antisignum {}
-pub const antisignum: Antisignum = Antisignum {};
+pub struct Antisignum;
+pub const antisignum: Antisignum = Antisignum;
 impl Recursive<U1> for Antisignum {}
 impl crate::compute::Compute<U1> for Antisignum {
     fn call(&self, x: &generic_array::GenericArray<usize, U1>) -> Option<usize> {
@@ -67,8 +67,8 @@ impl crate::compute::Compute<U1> for Antisignum {
 // }
 // Stopgap solution:
 #[derive(Debug)]
-pub struct Signum {}
-pub const signum: Signum = Signum {};
+pub struct Signum;
+pub const signum: Signum = Signum;
 impl Recursive<U1> for Signum {}
 impl crate::compute::Compute<U1> for Signum {
     fn call(&self, x: &generic_array::GenericArray<usize, U1>) -> Option<usize> {

--- a/src/funcs/common.rs
+++ b/src/funcs/common.rs
@@ -46,34 +46,12 @@ pub fn difference() -> impl Computable<U2> {
     pr!(id![U1, U1], cn![predecessor(); U3; id![U3, U3]])
 }
 
-// This causes segfaults in rust right now, hopefully it won't in the future
-// pub fn antisignum() -> impl Computable<U1> {
-//     cn![difference(); U1; cn![S; U1; Z], id![U1, U1]]
-// }
-// Stopgap solution:
-#[derive(Debug)]
-pub struct Antisignum;
-pub const antisignum: Antisignum = Antisignum;
-impl Recursive<U1> for Antisignum {}
-impl crate::compute::Compute<U1> for Antisignum {
-    fn call(&self, x: &generic_array::GenericArray<usize, U1>) -> Option<usize> {
-        Some(1usize.saturating_sub(x[0]))
-    }
+pub fn antisignum() -> impl Computable<U1> {
+    cn![difference(); U1; cn![S; U1; Z], id![U1, U1]]
 }
 
-// This causes segfaults in rust right now, hopefully it won't in the future
-// pub fn signum() -> impl Computable<U1> {
-//     cn![difference(); U1; cn![S; U1; Z], antisignum]
-// }
-// Stopgap solution:
-#[derive(Debug)]
-pub struct Signum;
-pub const signum: Signum = Signum;
-impl Recursive<U1> for Signum {}
-impl crate::compute::Compute<U1> for Signum {
-    fn call(&self, x: &generic_array::GenericArray<usize, U1>) -> Option<usize> {
-        Some(1usize.saturating_sub(1usize.saturating_sub(x[0])))
-    }
+pub fn signum() -> impl Computable<U1> {
+    cn![difference(); U1; cn![S; U1; Z], antisignum()]
 }
 
 #[cfg(test)]
@@ -116,11 +94,11 @@ mod test {
 
     #[quickcheck]
     fn antisignum_is_antisignum(x: usize) -> bool {
-        Some(1usize.saturating_sub(x)) == antisignum.call(args![x])
+        Some(1usize.saturating_sub(x)) == antisignum().call(args![x])
     }
 
     #[quickcheck]
     fn signum_is_signum(x: usize) -> bool {
-        Some(1usize.saturating_sub(1usize.saturating_sub(x))) == signum.call(args![x])
+        Some(1usize.saturating_sub(1usize.saturating_sub(x))) == signum().call(args![x])
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ pub use recursive::*;
 #[macro_export]
 macro_rules! funcs {
     ($N:ty; $($g:expr),*) => {
-        generic_array::arr![&'_ dyn crate::compute::Computable<$N>; $($g,)*]
+        generic_array::arr![Box<dyn crate::compute::Computable<$N>>; $(Box::new($g),)*]
     }
 }
 


### PR DESCRIPTION
`Box` computable functions being passed around to avoid dangling references. Allows for cleaning up (anti)signum.